### PR TITLE
Making the currency helper work with optional variable formats

### DIFF
--- a/helpers/currency-format.js
+++ b/helpers/currency-format.js
@@ -1,55 +1,68 @@
-const requiredForMonetary = ['locale', 'abbreviation'];
-const requiredForNonMonetary = ['singularName', 'pluralName', 'templateString'];
-
 /**
  * Takes some basic currency information and formats it in a locale-specific way.
- * @param {Number} amount This is how much
- * @param {Object} options This configures the display of the currency
- * @param {Boolean} options.isMoney Indicates wether this is monetary (euro) or not (a phone)
- * @param {String} options.locale For `isMoney: true`, this determines which locate to use (see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat)
- * @param {String} options.abbreviation An ISO 4217 designation for a monetary currency (https://en.wikipedia.org/wiki/ISO_4217)
- * @param {String} options.singularName For `isMoney: false`, this is displayed as NAME in
+ * @param {Object} params This configures the display of the currency
+ * @param {Number} params.amount This is how much
+ * @param {Boolean} params.currency.isMoney Indicates wether this is monetary (euro)
+ * or not (a phone)
+ * @param {String} params.locale For `isMoney: true`, this determines which locate to use (see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat)
+ * @param {String} params.currency.abbreviation An ISO 4217 designation for a monetary currency (https://en.wikipedia.org/wiki/ISO_4217)
+ * @param {String} params.currency.singularName For `isMoney: false`, this is displayed as NAME in
  * the case of 1
- * @param {String} options.pluralName For `isMoney: false`, this is displayed as NAME in
+ * @param {String} params.currency.pluralName For `isMoney: false`, this is displayed as NAME in
  * the case of >1
- * @param {String} options.templateString For `isMoney: false`, this specifies how the
+ * @param {String} params.format For `isMoney: false`, this specifies how the
  * currency will get rendered. The strings `{{currency}}` and `{{amount}}` will be replaced.
- * @param {String} options.decimalTerminator For `isMoney: true`, this supports a different
+ * @param {String} params.currency.decimalTerminator For `isMoney: true`, this supports a different
  * form of terminating a 00 value in cents
  * @return {String} in the case of isMoney, returns a local-sepcific currency string.
  * In the case of a non-monetary one, it uses a string template to format everything.
 */
-const formatCurrency = (amount, options) => {
-  if (typeof options.isMoney === 'undefined') throw new Error('options.isMoney is not set');
+const formatCurrency = params => {
+  /*
+    We look specifically for params.hash here because that is how Handlebars passes in
+    variable arguments:
 
-  (options.isMoney ? requiredForMonetary : requiredForNonMonetary).forEach(prop => {
-    if (typeof options[prop] === 'undefined') throw new Error(`options.${prop} is not set`);
-  });
+    https://handlebarsjs.com/block_helpers.html
+  */
+  const {
+    amount,
+    currency,
+    format,
+    locale
+  } = params.hash ? params.hash : params;
 
-  if (options.isMoney) {
+  if (typeof currency.isMoney === 'undefined') {
+    throw new Error('"currency.isMoney" is not set');
+  } else if (currency.isMoney === false && !format) {
+    throw new Error('"format" is not set for a non-monetary currency');
+  } else if (currency.isMoney && (!locale || !currency.abbreviation)) {
+    throw new Error('"locale" or "currency.abbreviation" is not set for a monetary currency');
+  }
+
+  if (currency.isMoney) {
     // Set the amount of decimals we want to show, it's 2 or 0
     const hasTrailingZeroZero = amount % 1 === 0;
     const localeOptions = {
       style: 'currency',
-      currency: options.abbreviation
+      currency: currency.abbreviation
     };
 
-    if (hasTrailingZeroZero && !options.decimalTerminator) {
+    if (hasTrailingZeroZero && !currency.decimalTerminator) {
       localeOptions.maximumFractionDigits = 0;
       localeOptions.minimumFractionDigits = 0;
     }
 
-    let localisedValue = new Intl.NumberFormat(options.locale, localeOptions).format(amount);
+    let localisedValue = new Intl.NumberFormat(locale, localeOptions).format(amount);
 
-    if (hasTrailingZeroZero && options.decimalTerminator) {
-      localisedValue = `${localisedValue.slice(0, -2)}${options.decimalTerminator}`;
+    if (hasTrailingZeroZero && currency.decimalTerminator) {
+      localisedValue = `${localisedValue.slice(0, -2)}${currency.decimalTerminator}`;
     }
 
     return localisedValue;
   }
 
-  const name = amount > 1 ? options.pluralName : options.singularName;
-  return options.templateString.replace('{{amount}}', amount).replace('{{currency}}', name);
+  const name = amount > 1 ? currency.pluralName : currency.singularName;
+  return format.replace('{{amount}}', amount).replace('{{currency}}', name);
 };
 
 module.exports = formatCurrency;

--- a/helpers/currency-format.js
+++ b/helpers/currency-format.js
@@ -61,7 +61,7 @@ const formatCurrency = params => {
     return localisedValue;
   }
 
-  const name = amount > 1 ? currency.pluralName : currency.singularName;
+  const name = amount === 1 ? currency.singularName : currency.pluralName;
   return format.replace('{{amount}}', amount).replace('{{currency}}', name);
 };
 

--- a/helpers/currency-format.js
+++ b/helpers/currency-format.js
@@ -31,7 +31,7 @@ const formatCurrency = params => {
     locale
   } = params.hash ? params.hash : params;
 
-  if (typeof currency.isMoney === 'undefined') {
+  if (typeof currency.isMoney !== 'boolean') {
     throw new Error('"currency.isMoney" is not set');
   } else if (currency.isMoney === false && !format) {
     throw new Error('"format" is not set for a non-monetary currency');

--- a/test/helpers/currency-format.test.js
+++ b/test/helpers/currency-format.test.js
@@ -47,10 +47,13 @@ test('currencyFormat() properly processes a non-monetary currency', () => {
 
   const pluralResult = Handlebars.compile(template)({ ...params, amount: 3 });
   const singleResult = Handlebars.compile(template)({ ...params, amount: 1 });
+  const nilResult = Handlebars.compile(template)({ ...params, amount: 0 });
 
   expect(typeof pluralResult).toBe('string');
   expect(pluralResult).toBe('3 staatsloten');
   expect(typeof singleResult).toBe('string');
   expect(singleResult).toBe('1 staatslot');
+  expect(typeof nilResult).toBe('string');
+  expect(nilResult).toBe('0 staatsloten');
 });
 

--- a/test/helpers/currency-format.test.js
+++ b/test/helpers/currency-format.test.js
@@ -3,48 +3,54 @@
 const Handlebars = require('handlebars');
 const helperFunction = require('../../helpers/currency-format');
 
+Handlebars.registerHelper('format-currency', helperFunction);
+
 test('currencyFormat() properly processes a monetary currency', () => {
-  const options = {
-    isMoney: true,
-    locale: 'de-DE',
-    abbreviation: 'EUR'
+  const template = '{{format-currency amount=amount currency=currency format=format locale=locale}}';
+  const params = {
+    currency: {
+      isMoney: true,
+      abbreviation: 'EUR'
+    },
+    locale: 'de',
+    amount: 42
   };
 
-  const result = helperFunction(25.43, options);
-
-  expect(typeof result).toBe('string');
-  expect(result).toBe('€ 25.43');
+  expect(Handlebars.compile(template)(params)).toBe('€ 42');
 });
 
 test('currencyFormat() properly processes a monetary currency with support for kastlijntje', () => {
-  const options = {
-    isMoney: true,
-    locale: 'de-DE',
-    abbreviation: 'EUR',
-    decimalTerminator: '-'
+  const template = '{{format-currency amount=amount currency=currency format=format locale=locale}}';
+  const params = {
+    currency: {
+      isMoney: true,
+      abbreviation: 'EUR',
+      decimalTerminator: '-'
+    },
+    locale: 'de',
+    amount: 42
   };
 
-  const result = helperFunction(25, options);
-
-  expect(typeof result).toBe('string');
-  expect(result).toBe('€ 25.-');
+  expect(Handlebars.compile(template)(params)).toBe('€ 42.-');
 });
 
 test('currencyFormat() properly processes a non-monetary currency', () => {
-  const options = {
-    isMoney: false,
-    singularName: 'staatslot',
-    pluralName: 'staatsloten',
-    templateString: '{{amount}} {{currency}}'
+  const template = '{{format-currency amount=amount currency=currency format=format}}';
+  const params = {
+    currency: {
+      isMoney: false,
+      singularName: 'staatslot',
+      pluralName: 'staatsloten'
+    },
+    format: '{{amount}} {{currency}}'
   };
 
-  Handlebars.registerHelper('currencyFormat', helperFunction);
-
-  const pluralResult = Handlebars.compile('{{currencyFormat 3 options}}')({ options });
-  const singleResult = Handlebars.compile('{{currencyFormat 1 options}}')({ options });
+  const pluralResult = Handlebars.compile(template)({ ...params, amount: 3 });
+  const singleResult = Handlebars.compile(template)({ ...params, amount: 1 });
 
   expect(typeof pluralResult).toBe('string');
   expect(pluralResult).toBe('3 staatsloten');
   expect(typeof singleResult).toBe('string');
   expect(singleResult).toBe('1 staatslot');
 });
+


### PR DESCRIPTION
See mgmco/bugs#2908

Basically, works with something like:

```hbs
{{format-currency amount=amount currency=currency format=format}}
```

Instead of the old massive `options` object.